### PR TITLE
Correct building placement & move player if it's blocking

### DIFF
--- a/controllers/modules/burner_to_burner.lua
+++ b/controllers/modules/burner_to_burner.lua
@@ -22,8 +22,8 @@ BurnerToBurnerModule = {
     {position={x=3, y=1}, resource="coal"}
   },
   buildings={
-    {type="burner-mining-drill", position={x=1, y=1}, direction=defines.direction.east},
-    {type="burner-mining-drill", position={x=3, y=1}}
+    {type="burner-mining-drill", position={x=0, y=0}, direction=defines.direction.east},
+    {type="burner-mining-drill", position={x=2, y=0}}
   },
   inputs={
     {building=1, type="coal", ongoing=false}

--- a/controllers/modules/burner_to_furnace.lua
+++ b/controllers/modules/burner_to_furnace.lua
@@ -22,8 +22,8 @@ BurnerToFurnaceModule = {
     {position={x=3, y=1}}
   },
   buildings={
-    {type="burner-mining-drill", position={x=1, y=1}, direction=defines.direction.east},
-    {type="stone-furnace", position={x=3, y=1}}
+    {type="burner-mining-drill", position={x=0, y=0}, direction=defines.direction.east},
+    {type="stone-furnace", position={x=2, y=0}}
   },
   inputs={
     {building=1, type="coal", ongoing=true},

--- a/controllers/tasks/placeBuildingTask.lua
+++ b/controllers/tasks/placeBuildingTask.lua
@@ -1,6 +1,7 @@
 require 'task'
 require 'util'
 require 'util/inventories'
+require 'util/collision'
 require 'controllers/tasks/moveToPointTask'
 
 --[[
@@ -22,8 +23,9 @@ end
 function PlaceBuildingTask:tick (args)
   local player = args.player;
   local prototype = game.entity_prototypes[self.type];
-  if(util.distance(player.position, self.position) > player_build_distance) then
-    args.machine:pushSingle(MoveToPointTask:new{x=self.position.x, y=self.position.y + prototype.collision_box.left_top.y - 1})
+  if(util.distance(player.position, self.position) > player_build_distance or
+          overlappingBoundingBox(player.position, game.entity_prototypes["player"].collision_box, self.position, prototype.collision_box)) then
+    args.machine:pushSingle(MoveToPointTask:new{x=self.position.x, y=self.position.y + prototype.collision_box.left_top.y - 2})
   else
     if(player.surface.can_place_entity{name=self.type, position=self.position, direction=self.direction, force=player.force}) then
       local inventories = Inventories.get_all_inventories(player);

--- a/util/collision.lua
+++ b/util/collision.lua
@@ -1,0 +1,4 @@
+function overlappingBoundingBox(aPos, a, bPos, b)
+  return aPos.x + a.left_top.x <= bPos.x + b.right_bottom.x and aPos.x + a.right_bottom.x >= bPos.x + b.left_top.x and
+          aPos.y + a.left_top.y <= bPos.y + b.right_bottom.y and aPos.y + a.right_bottom.y >= bPos.y + b.left_top.y
+end


### PR DESCRIPTION
This bothered me on stream so I had a look at it
As for the overlapping ores: you just had the buildings placed one unit too far, so it would check from (0,0)-(1,1), but you'd place it at (1,1)-(2,2)
I also added a quick check to see if player & building bounding boxes overlap (happens when it needs to move around to clear trees)

Little video for demonstration: http://share.dl.je/2016-09-29_10-10-12_ffVlMGkOFF.mp4 (the map editor is really helpful for making test maps)
